### PR TITLE
it's dup of my PR request from bitbucket: issue with endless parsing wrong headers

### DIFF
--- a/Source/ZipLib/detail/ZipGenericExtraField.cpp
+++ b/Source/ZipLib/detail/ZipGenericExtraField.cpp
@@ -10,15 +10,14 @@ bool ZipGenericExtraField::Deserialize(std::istream& stream, std::istream::pos_t
     return false;
   }
 
-  deserialize(stream, Tag);
-  deserialize(stream, Size);
+  if (!deserialize(stream, Tag) || !deserialize(stream, Size)) return false;
 
   if ((extraFieldEnd - stream.tellg()) < Size)
   {
     return false;
   }
 
-  deserialize(stream, Data, Size);
+  if (!deserialize(stream, Data, Size) && Size > 0) return false;
 
   return true;
 }


### PR DESCRIPTION
origin PR: https://bitbucket.org/wbenny/ziplib/pull-requests/10

deserialize returns a count of readed symbols from stream. This number is zero when stream has eof or fail bit

Modified Sample and broken archive for reproduce bug you can find here: https://bitbucket.org/ivan2201_2/ziplib/branch/issues/19